### PR TITLE
Hs auth

### DIFF
--- a/pysumma/hydroshare/compat.py
+++ b/pysumma/hydroshare/compat.py
@@ -1,0 +1,12 @@
+from __future__ import print_function
+import sys
+import urllib
+
+is_py2 = sys.version[0] == '2'
+if is_py2:
+    import Queue as queue
+    input = raw_input
+    urlencode = urllib.pathname2url
+else:
+    import queue as queue
+    urlencode = urllib.parse.quote

--- a/pysumma/hydroshare/hydroshare.py
+++ b/pysumma/hydroshare/hydroshare.py
@@ -1,0 +1,343 @@
+from __future__ import print_function
+import os
+import getpass
+import glob
+from IPython.core.display import display, HTML
+from hs_restclient import HydroShare, HydroShareAuthBasic
+from hs_restclient import HydroShareHTTPException
+from datetime import datetime as dt
+import pickle
+import shutil
+
+from . import threads
+from . import resource
+from . import utilities
+from .compat import *
+
+
+class hydroshare():
+    def __init__(self, username=None, password=None, cache=True):
+        self.hs = None
+        self.content = {}
+
+        # load the HS environment variables
+        # todo: this should be set as a path variable somehow.
+        #       possibly add JPY_TMP to Dockerfile
+        self.cache = cache
+        if cache:
+            utilities.load_environment(os.path.join(
+                                        os.environ['NOTEBOOK_HOME'], '.env'))
+        self.auth_path = '/home/jeff/.auth'
+
+        # todo: either use JPY_USR or ask them to
+        #       enter their hydroshare username
+        uname = username
+        if uname is None:
+            if 'HS_USR_NAME' in os.environ.keys():
+                uname = os.environ['HS_USR_NAME']
+
+        if password is None:
+            # get a secure connection to hydroshare
+            auth = self.getSecureConnection(uname)
+        else:
+            print('WARNING: THIS IS NOT A SECURE METHOD OF CONNECTING TO '
+                  'HYDROSHARE...AVOID TYPING CREDENTIALS AS PLAIN TEXT')
+            auth = HydroShareAuthBasic(username=uname, password=password)
+
+        try:
+            self.hs = HydroShare(auth=auth)
+            self.hs.getUserInfo()
+            print('Successfully established a connection with HydroShare')
+
+        except HydroShareHTTPException as e:
+            print('Failed to establish a connection with HydroShare.\n  '
+                  'Please check that you provided the correct credentials.\n'
+                  '%s' % e)
+
+            # remove the cached authentication
+            if os.path.exists(self.auth_path):
+                os.remove(self.auth_path)
+
+            return None
+
+    def _addContentToExistingResource(self, resid, content_files):
+
+        for f in content_files:
+            self.hs.addResourceFile(resid, f)
+
+    def getSecureConnection(self, username=None):
+        """Establishes a secure connection with hydroshare.
+
+        args:
+        -- email: email address associated with hydroshare
+
+        returns:
+        -- hydroshare api connection
+        """
+
+        if not os.path.exists(self.auth_path):
+            print('\nThe hs_utils library requires a secure connection to '
+                  'your HydroShare account.')
+            if username is None:
+                username = input('Please enter your HydroShare username: ') \
+                        .strip()
+            p = getpass.getpass('Enter the HydroShare password for user '
+                                '\'%s\': ' % username)
+            auth = HydroShareAuthBasic(username=username, password=p)
+
+            if self.cache:
+                with open(self.auth_path, 'wb') as f:
+                    pickle.dump(auth, f, protocol=2)
+
+        else:
+
+            with open(self.auth_path, 'rb') as f:
+                auth = pickle.load(f)
+
+        return auth
+
+    def getResourceMetadata(self, resid):
+        """Gets metadata for a specified resource.
+
+        args:
+        -- resid: hydroshare resource id
+
+        returns:
+        -- resource metadata object
+        """
+
+        science_meta = self.hs.getScienceMetadata(resid)
+        system_meta = self.hs.getSystemMetadata(resid)
+        return resource.ResourceMetadata(system_meta, science_meta)
+
+    def createHydroShareResource(self, abstract, title, derivedFromId=None,
+                                 keywords=[], resource_type='genericResource',
+                                 content_files=[], public=False):
+        """Creates a hydroshare resource.
+
+        args:
+        -- abstract: abstract for resource (str, required)
+        -- title: title of resource (str, required)
+        -- derivedFromId: id of parent hydroshare resource (str, default=>None)
+        -- keywords: list of subject keywords (list, default=>[])
+        -- resource_type: type of resource to create (str, default=>
+                                                     'GenericResource')
+        -- content_files: data to save as resource content (list, default=>[])
+        -- public: resource sharing status (bool, default=>False)
+
+        returns:
+        -- None
+        """
+
+        # query the hydroshare resource types and make sure that
+        # resource_type is valid
+        restypes = {r.lower(): r for r in self.hs.getResourceTypes()}
+        try:
+            res_type = restypes[resource_type]
+        except KeyError:
+            display(HTML('<b style="color:red;">[%s] is not a valid '
+                         'HydroShare resource type.</p>' % resource_type))
+            return None
+
+        # get the 'derived resource' metadata
+        if derivedFromId is not None:
+            try:
+                # update the abstract and keyword metadata
+                meta = self.getResourceMetadata(derivedFromId)
+
+                abstract = meta.abstract \
+                    + '\n\n[Modified in JupyterHub on %s]\n%s' \
+                    % (dt.now(), abstract)
+
+                keywords = set(keywords + meta.keywords)
+            except:
+                display(HTML('<b style="color:red;">Encountered an error '
+                             ' while setting the derivedFrom relationship '
+                             ' using id=%s. Make sure this resource is '
+                             ' is accessible to your account. '
+                             % derivedFromId))
+                display(HTML('<a href=%s target="_blank">%s<a>' %
+                             ('https://www.hydroshare.org/resource/%s'
+                              % derivedFromId, 'View the "DerivedFrom" '
+                              'Resource')))
+                return None
+
+        f = None if len(content_files) == 0 else content_files[0]
+
+        # create the hs resource (1 content file allowed)
+        resid = threads.runThreadedFunction('Creating HydroShare Resource',
+                                            'Resource Created Successfully',
+                                            self.hs.createResource,
+                                            resource_type=res_type,
+                                            title=title,
+                                            abstract=abstract,
+                                            resource_file=f,
+                                            keywords=keywords)
+
+        # add the remaining content files to the hs resource
+        try:
+            if len(content_files) > 1:
+                self.addContentToExistingResource(resid, content_files[1:])
+        except Exception as e:
+            print(e)
+
+        display(HTML('Resource id: %s' % resid))
+        display(HTML('<a href=%s target="_blank">%s<a>' %
+                     ('https://www.hydroshare.org/resource/%s'
+                      % resid, 'Open Resource in HydroShare')))
+        return resid
+
+    def getResourceFromHydroShare(self, resourceid, destination='.'):
+        """Downloads content of a hydroshare resource.
+
+        args:
+        -- resourceid: id of the hydroshare resource (str)
+        -- destination: path to save resource, default
+                        /user/[username]/notebooks/data (str)
+
+        returns:
+        -- None
+        """
+
+        # default_dl_path = utilities.get_env_var('NOTEBOOK_HOME')
+        dst = os.path.abspath(destination)
+        print (dst)
+        download = True
+
+        # check if the data should be overwritten
+        # dst_res_folder = os.path.join(dst, resourceid)
+        # if os.path.exists(dst_res_folder):
+            # res = input('This resource already exists in your userspace.'
+                        # '\nWould you like to overwrite this data [Y/n]? ')
+            # if res != 'n':
+                # shutil.rmtree(dst_res_folder)
+            # else:
+                # download = False
+
+        # re-download the content if desired
+        if download:
+            try:
+
+                # download the resource (threaded)
+                threads.runThreadedFunction('Downloading Resource',
+                                            'Download Finished',
+                                            self.hs.getResource,
+                                            resourceid,
+                                            destination=dst,
+                                            unzip=True)
+
+                print('Successfully downloaded resource %s' % resourceid)
+
+            except Exception as e:
+                display(HTML('<b style="color:red">Failed to retrieve '
+                             'resource content from HydroShare: %s</b>' % e))
+                return None
+
+        # load the resource content
+        # outdir = os.path.join(dst, '%s/%s' % (resourceid, resourceid))
+        # content_files = glob.glob(os.path.join(outdir, 'data/contents/*'))
+
+        # content = {}
+        # for f in content_files:
+            # fname = os.path.basename(f)
+
+            # trim the base name relative to the data directory
+            # dest_folder_name = os.path.dirname(destination).split('/')[-1]
+            # f = os.path.join(dest_folder_name,
+                             # os.path.relpath(f, dest_folder_name))
+
+            # content[fname] = f
+
+        # show the resource content files
+        # utilities.display_resource_content_files(content)
+
+        # update the content dictionary
+        # self.content.update(content)
+
+    def addContentToExistingResource(self, resid, content):
+        """Adds content files to an existing hydroshare resource.
+
+        args:
+        -- resid: id of an existing hydroshare resource (str)
+        -- content: files paths to be added to resource (list)
+
+        returns:
+        -- None
+        """
+
+        threads.runThreadedFunction('Adding Content to Resource',
+                                    'Successfully Added Content Files',
+                                    self._addContentToExistingResource,
+                                    resid, content)
+
+    def loadResource(self, resourceid):
+        """Loads the contents of a previously downloaded resource.
+
+         args:
+         -- resourceid: the id of the resource that has been downloaded (str)
+
+         returns:
+         -- {content file name: path}
+        """
+
+        resdir = utilities.find_resource_directory(resourceid)
+        if resdir is None:
+            display(HTML('<b style="color:red">Could not find any resource '
+                         'matching the id [%s].</b> <br> It is likely that '
+                         'this resource has not yet been downloaded from '
+                         'HydroShare.org, or it was removed from the '
+                         'JupyterHub server. Please use the following '
+                         'command to aquire the resource content: '
+                         '<br><br><code>hs.getResourceFromHydroShare(%s)'
+                         '</code>.' % (resourceid, resourceid)))
+            return
+        
+        # create search paths.  Need to check 2 paths due to hs_restclient bug #63.
+        search_paths = [os.path.join(resdir, '%s/data/contents/*' % resourceid), 
+                        os.path.join(resdir, 'data/contents/*')]
+                        
+        content = {}
+        found_content = False
+        for p in search_paths:
+            content_files = glob.glob(p)
+            if len(content_files) > 0:
+                found_content = True
+                display(HTML('<p>Downloaded content is located at: %s</p>' % resdir))
+                display(HTML('<p>Found %d content file(s). \n</p>'
+                             % len(content_files)))
+            for f in content_files:
+                fname = os.path.basename(f)
+                content[fname] = f
+        if len(content.keys()) == 0:
+            display(HTML('<p>Did not find any content files for resource id: %s</p>' % resourceid))
+
+        utilities.display_resource_content_files(content)
+        self.content = content
+
+    def getContentFiles(self, resourceid):
+        """Gets the content files for a resource that exists on the
+           Jupyter Server
+
+        args:
+        -- resourceid: the id of the hydroshare resource
+
+        returns:
+        -- {content file name: path}
+        """
+
+        content = utilities.get_hs_content(resourceid)
+        return content
+
+    def getContentPath(self, resourceid):
+        """Gets the server path of a resources content files.
+
+        args:
+        -- resourceid: the id of the hydroshare resource
+
+        returns:
+        -- server path the the resource content files
+        """
+
+        path = utilities.find_resource_directory(resourceid)
+        if path is not None:
+            return os.path.join(path, resourceid, 'data/contents')

--- a/pysumma/hydroshare/hydroshare.py
+++ b/pysumma/hydroshare/hydroshare.py
@@ -23,11 +23,11 @@ class hydroshare():
         # load the HS environment variables
         # todo: this should be set as a path variable somehow.
         #       possibly add JPY_TMP to Dockerfile
-        self.cache = cache
-        if cache:
-            utilities.load_environment(os.path.join(
-                                        os.environ['NOTEBOOK_HOME'], '.env'))
-        self.auth_path = '/home/jeff/.auth'
+        # self.cache = cache
+        # if cache:
+            # utilities.load_environment(os.path.join(
+                                        # os.environ['NOTEBOOK_HOME'], '.env'))
+        self.auth_path = os.path.join(os.path.expanduser('~'), '.auth')
 
         # todo: either use JPY_USR or ask them to
         #       enter their hydroshare username
@@ -85,9 +85,8 @@ class hydroshare():
                                 '\'%s\': ' % username)
             auth = HydroShareAuthBasic(username=username, password=p)
 
-            if self.cache:
-                with open(self.auth_path, 'wb') as f:
-                    pickle.dump(auth, f, protocol=2)
+            with open(self.auth_path, 'wb') as f:
+                pickle.dump(auth, f, protocol=2)
 
         else:
 

--- a/pysumma/hydroshare/progress.py
+++ b/pysumma/hydroshare/progress.py
@@ -1,0 +1,76 @@
+import sys
+import itertools
+
+class progressBar(object):
+
+    def __init__(self, progress_message, type='pulse', refresh_delay=0.25,
+                 finish_message='Finished', error_message='An error has occurred'):
+
+        # create a simple progress bar
+        self.barArray = itertools.cycle(self._pulseArrays(type))
+        self.refreshDelay = float(refresh_delay)
+
+        self.messagelen = 0
+
+        self.msg = '\r' + progress_message
+        self.fin = '\r' + finish_message 
+        self.err = '\r' + error_message 
+        
+        self.overwrite_progress_length = len(self.msg) + 21
+
+    def _pulseArrays(self, ptype='pulse'):
+
+        types = ['pulse', 'dial', 'dots']
+
+        # set default bar type to 'pulse' if unknown type is provided
+        if ptype not in types:
+            ptype = 'pulse'
+
+        if ptype == 'pulse':
+            parray = ['___________________'] * 20
+            parray = [parray[i][:i] + '/\\' + parray[i][i:] for i in range(len(parray))]
+            parray = parray + parray[-2:0:-1]
+
+        elif ptype == 'dial':
+            parray = ['-', '\\', '|', '/', '-', '\\', '|', '/']
+
+        elif ptype == 'dots':
+            parray = [' ']*19
+            parray = ['.'*i + ''.join(parray[i:]) for i in range(len(parray))]
+#            parray = ['.'*i for i in range(20)]
+
+        return parray
+
+    def _clearLine(self):
+        chars = len(self.msg) + 27
+
+        sys.stdout.write('\r%s' % (chars * ' '))
+        sys.stdout.flush()
+
+    def updateProgressMessage(self, msg):
+        self.msg = '\r' + msg
+
+    def writeprogress(self):
+        # self._clearLine()
+        msg = '\r' + ' '.join([self.msg, next(self.barArray)])
+        #msg += 'x'*(len(self.msg) - len(msg))
+        sys.stdout.write(msg)
+
+        sys.stdout.flush()
+    
+    def success(self):
+        self._clearLine()
+        sys.stdout.write(self.fin + '\n')
+        sys.stdout.flush()
+    
+    def error(self):
+        self._clearLine()
+        sys.stdout.write(self.err + '\n')
+        sys.stdout.flush()
+
+    def update(self, *args):
+        self._clearLine()
+        msg = self.msg + ' %s  '
+        args += tuple([next(self.barArray)])
+        sys.stdout.write(msg % args)
+        sys.stdout.flush()

--- a/pysumma/hydroshare/resource.py
+++ b/pysumma/hydroshare/resource.py
@@ -1,0 +1,19 @@
+
+
+class ResourceMetadata (object):
+    def __init__(self, system_meta, science_meta):
+
+        self.__dict__.update(science_meta)
+        self.__dict__.update(system_meta)
+
+    @property
+    def url(self):
+        return self.resource_url
+
+    @property
+    def abstract(self):
+        return self.description
+
+    @property
+    def keywords(self):
+        return [s['value'] for s in self.subjects]

--- a/pysumma/hydroshare/threads.py
+++ b/pysumma/hydroshare/threads.py
@@ -1,0 +1,61 @@
+from __future__ import print_function
+import time
+from threading import Thread
+
+from . import progress
+from .compat import *
+
+
+class threadWrapper(object):
+    def __init__(self, func):
+        self.func = func
+        self.results = queue.Queue()
+
+    def run(self, *args, **kwargs):
+
+        # create a thread to run the function in
+        self.thread = Thread(target=self.f, args=args, kwargs=kwargs)
+
+        # start the thread
+        self.thread.start()
+
+    def f(self, *args, **kwargs):
+        res = self.func(*args, **kwargs)
+        self.results.put(res)
+
+    def close(self):
+        self.thread.join()
+
+    def result(self):
+        results = None
+        if not self.results.empty():
+            results = self.results.get()
+        return results
+
+    def isAlive(self):
+        return self.thread.isAlive()
+
+    def join(self):
+        self.thread.join()
+
+def runThreadedFunction(msg, success, func, *args, **kwargs):
+
+    pbar = progress.progressBar(msg, type='dial',
+                                finish_message=success)
+
+    # create a thread for the function
+    threaded_func = threadWrapper(func)
+    threaded_func.run(*args, **kwargs)
+
+    # print message while the function is running
+    while(threaded_func.isAlive()):
+        time.sleep(.2)
+        pbar.writeprogress()
+
+    # join the thread
+    threaded_func.join()
+    pbar.success()
+
+    res = threaded_func.result()
+
+    return res

--- a/pysumma/hydroshare/utilities.py
+++ b/pysumma/hydroshare/utilities.py
@@ -1,0 +1,125 @@
+from __future__ import print_function
+import os, sys
+from IPython.core.display import display, HTML
+import glob
+
+from .compat import *
+
+
+def sizeof_fmt(num, suffix='B'):
+    for unit in ['', 'Ki', 'Mi', 'Gi', 'Ti', 'Pi', 'Ei', 'Zi']:
+        if abs(num) < 1024.0:
+            return "%3.1f%s%s" % (num, unit, suffix)
+        num /= 1024.0
+    return "%.1f%s%s" % (num, 'Yi', suffix)
+
+def get_hs_content(resid):
+
+    resdir = find_resource_directory(resid)
+
+    content = {}
+    for f in glob.glob('%s/*/data/contents/*' % resdir):
+        fname = os.path.basename(f)
+        content[fname] = f
+
+    return content
+
+def find_resource_directory(resid):
+   
+    basedir = os.environ['NOTEBOOK_HOME']
+   
+    # loop over all the files in userspace
+    for dirpath, dirnames, filenames in os.walk(basedir):
+        for dirname in [d for d in dirnames]:
+            if dirname == resid:
+                return os.path.join(dirpath, dirname)
+    return None
+
+def check_for_ipynb(content_files):
+
+    links = {}
+    for f, p in content_files.items():
+        if f[-5:] == 'ipynb':
+            fname = os.path.basename(p)
+            url = urlencode(p)
+            links[fname] = url
+    return links
+
+def display_tree(resid):
+
+    # todo: display a tree view of the resource bagit, based on id
+    pass
+
+def display_resource_content_files(content_file_dictionary,
+                                   text='Found the following content when parsing the HydroShare resource:'):
+    
+    # get ipynb files
+    nbs = check_for_ipynb(content_file_dictionary)
+    if len(nbs.keys()) > 0:
+        display(HTML('<b>Found the following notebook(s) associated with this HydroShare resource.</b><br>Click the link(s) below to launch the notebook.'))
+        
+        for name, url in nbs.items():
+            display(HTML('<a href=%s target="_blank">%s<a>' % (url, name)))
+
+    # print the remaining files    
+    if len(content_file_dictionary.keys()) > 0:
+        display(HTML('<b>Found the following file(s) associated with this HydroShare resource.</b>'))
+        
+        text = '<br>'.join(content_file_dictionary.keys())
+        display(HTML(text))
+    
+    if (len(content_file_dictionary.keys()) + len(nbs.keys())) > 0:
+        display(HTML('These files are stored in a dictionary called <b>hs.content</b> for your convenience.  To access a file, simply issue the following command where MY_FILE is one of the files listed above: <pre>hs.content["MY_FILE"] </pre> '))
+
+
+def load_environment(env_path=None):
+
+    # load the environment path (if it exists)
+    if env_path is None:
+        if 'NOTEBOOK_HOME' in os.environ.keys():
+            env_path = os.path.join(os.environ['NOTEBOOK_HOME'], '.env')
+
+    if not os.path.exists(env_path):
+        print('\nEnvironment file could not be found.  Make sure that the JUPYTER_ENV variable is set properly')
+        return
+
+    with open(env_path, 'r') as f:
+        lines = f.readlines()
+        print('Adding the following system variables:')
+        for line in lines:
+            k, v = line.strip().split('=')
+            os.environ[k] = v
+            print('   %s = %s' % (k, v))
+        print('\nThese can be accessed using the following command: ')
+        print('   os.environ[key]')
+        print('\n   (e.g.)\n   os.environ["HS_USR_NAME"]  => %s' % os.environ['HS_USR_NAME'])
+
+def get_env_var(varname):
+    if varname in os.environ.keys():
+        return os.environ[varname]
+    else:
+        return input('Could not find %s, please specify a value: ' % varname).strip()
+
+def get_server_url_for_path(p):
+    """
+    gets the url corresponding to a given file or directory path
+    p : path to convert into a url
+
+    returns the url path for the filepath p
+    """
+
+    load_environment()
+    fname = os.path.basename(p)
+    rel_path = os.path.relpath(p, os.environ['NOTEBOOK_HOME'])
+    url = urlencode(rel_path)
+    return url
+
+def get_relative_path(p):
+    """
+    gets the path relative to the jupyter home directory
+    p: path to convert into relative path
+
+    returns the path relative to the default jupyter home directory
+    """
+
+    return os.path.relpath(p, os.environ['NOTEBOOK_HOME'])

--- a/pysumma/utils.py
+++ b/pysumma/utils.py
@@ -2,6 +2,7 @@ import shutil
 import os
 from urllib.request import urlretrieve
 import subprocess
+from hs_restclient import HydroShare
 
 
 class utils():
@@ -13,9 +14,10 @@ class utils():
         cmd = "cd {}/summaTestCases_2.x/; ./installTestCases_local.sh".format(directory)
         subprocess.run(cmd, shell=True)
 
-    def install_test_cases_hs(hs, resource_id, save_filepath):
-        authen = hs
-        authen.getResource(resource_id, destination = save_filepath, unzip = True)
+    def install_test_cases_hs(save_filepath):
+        resource_id = 'a0105d479c334764ba84633c5b9c1c01'
+        hs = HydroShare()
+        hs.getResource(resource_id, destination = save_filepath, unzip = True)
         resource_name = 'summatestcases-2.x.tar.gz'
         testcase_filepath = save_filepath + '/' + resource_id + '/' + resource_id + '/data/contents/' + resource_name
         shutil.unpack_archive(testcase_filepath, extract_dir=os.path.dirname(testcase_filepath))

--- a/setup.py
+++ b/setup.py
@@ -7,5 +7,5 @@ setup(name='pysumma',
       author = 'YoungDon Choi',
       author_email = 'yc5ef@virginia.edu',
       license = 'BSD-3-Clause',
-      packages=['pysumma'],
+      packages=find_packages(),
       test_suite = 'pysumma.tests')


### PR DESCRIPTION
@arbennett - code in the `hydroshare` directory adds authorization functionality so that users do not need to store plain text credentials in a jupyter notebook to connect to hydroshare. The edit to the `setup.py` makes it so the `hydroshare` package is installed as well as the files in the `pysumma` directory (e.g., `Simulation.py`). 