### PR TITLE
Feature/library path

### DIFF
--- a/pysumma/Simulation.py
+++ b/pysumma/Simulation.py
@@ -39,7 +39,7 @@ class Simulation:
             # read every line of filemanager and return as list format
             return f.readlines()
 
-    def execute(self, run_suffix, run_option):
+    def execute(self, run_suffix, run_option, arglist=[]):
         self.run_suffix = run_suffix
         if run_option == 'local':
             cmd = "{} -p never -s {} -m {}".format(self.executable, self.run_suffix, self.filepath)
@@ -63,16 +63,22 @@ class Simulation:
         else:
             raise ValueError('No executable defined. Set as "executable" attribute of Simulation or check run_option')
         # run shell script in python
+        preprocess = []
         if self.library_path:
-            cmd = "".join(['export LD_LIBRARY_PATH="{}";'.format(self.library_path),
-                          cmd])
+            preprocess = ['export LD_LIBRARY_PATH="{}" && '.format(self.library_path)]
+        if arglist:
+            preprocess.append('{} && '.join(arglist))
+        preprocess = "".join(preprocess)
+        cmd = preprocess + " && " + cmd
+        print(preprocess)
+        print(cmd)
         proc = subprocess.Popen(cmd, shell=True, stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         # define output file name
         out_file_path = self.output_path.filepath + \
                         self.output_prefix.value + 'output_' + \
                         self.run_suffix + '_timestep.nc'
-        return xr.open_dataset(out_file_path), out_file_path
+        return proc, out_file_path
 
 
 class FileManagerOption(Option):

--- a/pysumma/Simulation.py
+++ b/pysumma/Simulation.py
@@ -20,7 +20,7 @@ class Simulation:
         self.meta_type = FileManagerOption(self, 'meta_type')
         self.meta_force = FileManagerOption(self, 'meta_force')
         self.meta_localpar = FileManagerOption(self, 'meta_localpar')
-        self.OUTPUT_CONTROL = FileManagerOption(self, 'OUTPUT_CONTROL')
+        self.OUTPUT_CONTROL = FileManagerOption(self, 'output_control')
         self.meta_index = FileManagerOption(self, 'meta_index')
         self.meta_basinpar = FileManagerOption(self, 'meta_basinpar')
         self.meta_basinvar = FileManagerOption(self, 'meta_basinvar')
@@ -63,10 +63,14 @@ class Simulation:
         else:
             raise ValueError('No executable defined. Set as "executable" attribute of Simulation or check run_option')
         # run shell script in python
-        subprocess.run(cmd, shell=True)
+        if self.library_path:
+            cmd = "".join(['export LD_LIBRARY_PATH="{}";'.format(self.library_path),
+                          cmd])
+        proc = subprocess.Popen(cmd, shell=True, stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         # define output file name
         out_file_path = self.output_path.filepath + \
-                        self.output_prefix.value + '_output_' + \
+                        self.output_prefix.value + 'output_' + \
                         self.run_suffix + '_timestep.nc'
         return xr.open_dataset(out_file_path), out_file_path
 


### PR DESCRIPTION
This pull request adds the capability to set the library path and other pre-run commands.  Setting the library path may be necessary if SUMMA is compiled with non-system libraries.  Additional pre-run arguments may include setting the number of threads, or deleting old data.  This also changes the execute command so that it returns a process handle that pipes the stdout and stderr so that the run can be monitored.