### PR TITLE
Add ability to rerun failed ensemble members

### DIFF
--- a/pysumma/ensemble.py
+++ b/pysumma/ensemble.py
@@ -142,6 +142,35 @@ class Ensemble(object):
         for s in simulations:
             self.simulations[s.run_suffix] = s
 
+    def summary(self):
+        """
+        Show the user information about ensemble status
+        """
+        success, error, other = [], [], []
+        for n, s in self.simulations.items():
+            if s.status == 'Success':
+                success.append(n)
+            elif s.status == 'Error':
+                error.append(n)
+            else:
+                other.append(n)
+        return {'success': success, 'error': error, 'other': other}
+
+    def rerun_failed(self, run_option: str, prerun_cmds=None,
+                     monitor: bool=True):
+        run_summary = self.summary()
+        self.submissions = []
+        for n in run_summary['error']:
+            config = self.configuration[n]
+            s = self.simulations[n]
+            self.submissions.append(self._client.submit(
+                _submit, s, n, run_option, prerun_cmds, config))
+            time.sleep(2.0)
+        if monitor:
+            return self.monitor()
+        else:
+            return True
+
 
 def _submit(s: Simulation, name: str, run_option: str, prerun_cmds, config):
     s.initialize()

--- a/pysumma/ensemble.py
+++ b/pysumma/ensemble.py
@@ -128,6 +128,18 @@ class Ensemble(object):
             time.sleep(2.0)
 
     def run(self, run_option: str, prerun_cmds=None, monitor: bool=True):
+        """
+        Run the ensemble
+
+        Parameters
+        ----------
+        run_option:
+            Where to run the simulation. Can be ``local`` or ``docker``
+        prerun_cmds:
+            A list of shell commands to run before running SUMMA
+        monitor:
+            Whether to halt operation until runs are complete
+        """
         self.start(run_option, prerun_cmds)
         if monitor:
             return self.monitor()
@@ -158,6 +170,18 @@ class Ensemble(object):
 
     def rerun_failed(self, run_option: str, prerun_cmds=None,
                      monitor: bool=True):
+        """
+        Try to re-run failed simulations.
+
+        Parameters
+        ----------
+        run_option:
+            Where to run the simulation. Can be ``local`` or ``docker``
+        prerun_cmds:
+            A list of shell commands to run before running SUMMA
+        monitor:
+            Whether to halt operation until runs are complete
+        """
         run_summary = self.summary()
         self.submissions = []
         for n in run_summary['error']:


### PR DESCRIPTION
This also adds a helper method `summary` on the `Ensemble` object, which easily let's you see which runs have completed successfully, failed, or have indeterminate status.