### PR TITLE
add meta folder of calibration MANIFEST.in and change code to read netcdf in file_manager.py

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include pysumma/meta/*
+include pysumma/calibration/meta/*

--- a/pysumma/file_manager.py
+++ b/pysumma/file_manager.py
@@ -94,22 +94,25 @@ class FileManager(OptionContainer):
     def local_attributes(self):
         p1 = self.get_value('settingsPath')
         p2 = self.get_value('attributeFile')
-        self._local_attrs = xr.open_dataset(p1 + p2)
-        return self._local_attrs
+        with xr.open_dataset(p1 + p2) as self._local_attrs:
+        	self._local_attrs.load()
+        return self._local_attrs.load()
 
     @property
     def trial_params(self):
         p1 = self.get_value('settingsPath')
         p2 = self.get_value('trialParamFile')
-        self._trial_params = xr.open_dataset(p1 + p2)
-        return self._trial_params
+        with xr.open_dataset(p1 + p2) as self._trial_params:
+        	self._trial_params.load()
+        return self._trial_params.load()
 
     @property
     def initial_conditions(self):
         p1 = self.get_value('settingsPath')
         p2 = self.get_value('initConditionFile')
-        self._init_cond = xr.open_dataset(p1 + p2)
-        return self._init_cond
+        with xr.open_dataset(p1 + p2) as self._init_cond:
+        	self._init_cond.load()
+        return self._init_cond.load()
 
     @property
     def genparm(self):


### PR DESCRIPTION
1. add meta folder of calibration folder in MANIFEST.in
2. change open NetCDF to avoid an overwriting problem