### PR TITLE
Change the values in self.manager for Docker run

### DIFF
--- a/pysumma/simulation.py
+++ b/pysumma/simulation.py
@@ -254,11 +254,10 @@ class Simulation():
         run_cmd = run_cmd.replace(self.executable, '/code/bin/summa.exe')
 
         fman_dir = os.path.dirname(self.manager_path)
-        settings_path = self.manager['settings_path'].value
-        input_path = self.manager['input_path'].value
-        output_path = self.manager['output_path'].value
+        settings_path = self.manager['settingsPath'].value
+        input_path = self.manager['forcingPath'].value
+        output_path = self.manager['outputPath'].value
         cmd = ''.join(['docker run -v {}:{}'.format(fman_dir, fman_dir),
-                       ' -v {}:{}'.format(settings_path, settings_path),
                        ' -v {}:{}'.format(input_path, input_path),
                        ' -v {}:{} '.format(output_path, output_path),
                        " --entrypoint '/bin/bash' ",


### PR DESCRIPTION
1. Changed the values in self.manager for Docker run to corresponding to metadata.
2. When I executed Docker, I got an error "Mount Duplicate point".
   So I deleted one of the command `-v {}:{}'.format(settings_path, settings_path)` to avoid the duplication of `-v {}:{}'.format(fman_dir, fman_dir)`.