### PR TITLE
Improve handling of Ostrich with some helper functions/validation

### DIFF
--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -1,0 +1,17 @@
+What's new
+===========
+
+.. _whats_new_develop
+
+Develop version
+---------------
+
+Enhancements
+~~~~~~~~~~~~
+- Improve usability of Ostrich calibration by adding validation of options before runtime
+- Improve usability of Ostrich calibration by allowing testing of the runscript
+- Improve usability of Ostrich calibration by adding helper functions to read in metrics and parameter logs
+
+Bug fixes
+~~~~~~~~~
+- Fixes a bug in the Ostrich run script that assumes an `hruIndex` variable in the parameter dataset.

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -12,6 +12,9 @@ Enhancements
 - Improve usability of Ostrich calibration by allowing testing of the runscript
 - Improve usability of Ostrich calibration by adding helper functions to read in metrics and parameter logs
 - Improve usability of Ostrich calibration by attempting to infer the python executable even when running inside of an environment.
+- Filter for multiple output files when calibrating.
+- Convert path for observed data to absolute path implicitly when calibrating.
+- Allow for user specified cost functions during calibration.
 
 Bug fixes
 ~~~~~~~~~

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -11,6 +11,7 @@ Enhancements
 - Improve usability of Ostrich calibration by adding validation of options before runtime
 - Improve usability of Ostrich calibration by allowing testing of the runscript
 - Improve usability of Ostrich calibration by adding helper functions to read in metrics and parameter logs
+- Improve usability of Ostrich calibration by attempting to infer the python executable even when running inside of an environment.
 
 Bug fixes
 ~~~~~~~~~

--- a/pysumma/calibration/meta/model_executable.template
+++ b/pysumma/calibration/meta/model_executable.template
@@ -7,6 +7,10 @@ import xarray as xr
 import numpy as np
 $importStrings
 
+$functionStrings
+
+$costFunctionCode
+
 if __name__ == '__main__':
     # Template variables
     summa_exe = '$summaExe'
@@ -23,6 +27,31 @@ if __name__ == '__main__':
     simulation_args = $simulationArgs
     conversion = $conversionFunc
     filter = $filterFunc
+    cost_function = '$costFunction'.lower()
+    maximize = $maximize
+
+    metrics_mapping = {
+       'kge': pse.kling_gupta_efficiency,
+       'nse': pse.nash_sutcliffe_efficiency,
+       'mae': pse.mean_absolute_error,
+       'rmse': pse.root_mean_square_error,
+       'mse': pse.mean_squared_error
+    }
+    if cost_function not in metrics_mapping:
+        metrics_mapping[cost_function] = $costFunction
+    # default metrics are used when model failure occurs
+    default_metrics = {
+        'kge': -9999.0,
+        'nse': -9999.0,
+        'mae': 9999.0,
+        'mse': 99999.0,
+        'rmse': 9999.0,
+    }
+    if cost_function not in default_metrics:
+        if maximize:
+            default_metrics[cost_function] = -9999.0
+        else:
+            default_metrics[cost_function] = 9999.0
 
     # read in parameters from ostrich files and summa setup
     with xr.open_dataset(param_file) as temp:
@@ -33,10 +62,9 @@ if __name__ == '__main__':
         for line in weights:
             name, value = line.split('|')
             param_dict[name.strip()] = float(value.strip())
-
     # insert calibration parameters from ostrich
     for k, v in param_dict.items():
-        trial_params[k] = xr.full_like(trial_params['hru'], fill_value=v)
+        trial_params[k] = xr.full_like(trial_params['hru'], fill_value=v, dtype=np.float64)
     trial_params.to_netcdf(param_file)
 
     # initialize simulation object
@@ -45,32 +73,34 @@ if __name__ == '__main__':
         os.remove(out_file)
     # run the simulation
     s.run('local')
+
+    # error handling
     if s.status != 'Success':
         print(s.stdout)
         print('--------------------------------------------')
         print(s.stderr)
         if allow_failures:
-            kge = -3
-            nse = -3
-            mae = 9999.0
-            mse = 999999.0
-            rmse = 9999.0
             with open(out_file, 'w+') as f:
-                f.write('%.6f'%kge  + '\t #KGE\n')
-                f.write('%.6f'%mae  + '\t #MAE\n')
-                f.write('%.6f'%mse  + '\t #MSE\n')
-                f.write('%.6f'%rmse + '\t #RMSE\n')
-                f.write('%.6f'%nse  + '\t #NSE\n')
+                for k, v in default_metrics.items():
+                    f.write('%.6f'%v + f'\t #{k}\n')
 
             with open(metrics_log, 'a') as f:
-                f.write('%.6f'%kge  + ', %.6f'%mae
-                        + ', %.6f'%mse + ', %.6f'%rmse
-                        + ', %.6f'%nse + '\n')
+                f.write(', '.join(['%.6f'%v for v in default_metrics.values()]) + '\n')
 
     assert s.status == 'Success'
 
     # open output and calculate diagnostics
-    sim_ds = s.output.load()
+    if type(s.output) == list:
+        all_errs = []
+        for out_ds in s.output:
+            try:
+                sim_ds = out_ds[sim_calib_vars].load()
+            except KeyError as e:
+                all_errs.append(e)
+        if not sim_ds:
+            raise Exception(all_errs)
+    else:
+        sim_ds = s.output.load()
     obs_ds = xr.open_dataset(obs_data_file).load()
 
     # trim sim and obs to common time length
@@ -79,31 +109,17 @@ if __name__ == '__main__':
     obs_ds = obs_ds.sel(time=time_slice)
     sim_filt, obs_filt = filter(sim_ds,  obs_ds)
 
-    kge_list = []
-    mae_list = []
-    mse_list = []
-    rmse_list = []
-    nse_list = []
-    for simvar, obsvar in zip(sim_calib_vars, obs_calib_vars):
-        kge_list.append(pse.kling_gupta_efficiency(sim_filt[simvar], conversion(obs_filt[obsvar])))
-        mae_list.append(pse.mean_absolute_error(sim_filt[simvar], conversion(obs_filt[obsvar])))
-        mse_list.append(pse.mean_squared_error(sim_filt[simvar], conversion(obs_filt[obsvar])))
-        rmse_list.append(pse.root_mean_square_error(sim_filt[simvar], conversion(obs_filt[obsvar])))
-        nse_list.append(pse.nash_sutcliffe_efficiency(sim_filt[simvar], conversion(obs_filt[obsvar])))
-
-    kge = np.mean(kge_list)
-    mae = np.mean(mae_list)
-    mse = np.mean(mse_list)
-    rmse = np.mean(rmse_list)
-    nse = np.mean(nse_list)
-
-    # save diagnostics in form that ostrich can read
+    metrics_dict = {}
     with open(out_file, 'w+') as f:
-        f.write('%.6f'%kge  + '\t #KGE\n')
-        f.write('%.6f'%mae  + '\t #MAE\n')
-        f.write('%.6f'%mse  + '\t #MSE\n')
-        f.write('%.6f'%rmse + '\t #RMSE\n')
-        f.write('%.6f'%nse  + '\t #NSE\n')
+        for metric, metric_fun in metrics_mapping.items():
+            metric_list = []
+            for simvar, obsvar in zip(sim_calib_vars, obs_calib_vars):
+                metric_list.append(metric_fun(
+                    sim_filt[simvar], conversion(obs_filt[obsvar])))
+            metric_val = np.mean(metric_list)
+            # save diagnostics in form that ostrich can read
+            f.write('%.6f'%metric_val + f'\t #{metric}\n')
+            metrics_dict[metric] = metric_val
 
     with open(metrics_log, 'a') as f:
-        f.write('%.6f'%kge  + ', %.6f'%mae + ', %.6f'%mse + ', %.6f'%rmse + ', %.6f'%nse + '\n')
+        f.write(', '.join(['%.6f'%v for v in metrics_dict.values()]) + '\n')

--- a/pysumma/calibration/meta/model_executable.template
+++ b/pysumma/calibration/meta/model_executable.template
@@ -36,7 +36,7 @@ if __name__ == '__main__':
 
     # insert calibration parameters from ostrich
     for k, v in param_dict.items():
-        trial_params[k] = xr.full_like(trial_params['hruIndex'], fill_value=v)
+        trial_params[k] = xr.full_like(trial_params['hru'], fill_value=v)
     trial_params.to_netcdf(param_file)
 
     # initialize simulation object

--- a/pysumma/calibration/ostrich.py
+++ b/pysumma/calibration/ostrich.py
@@ -3,6 +3,7 @@ import pandas as pd
 import numpy as np
 import shutil
 import stat
+import sys
 import inspect
 import subprocess
 from functools import partial
@@ -61,7 +62,9 @@ class Ostrich():
     ostrich:
         Path to OSTRICH executable
     python_path:
-        Path to Python executable used for the ``run_script``
+        Path to Python executable used for the ``run_script``.
+        Note, you may need to set this if you are running the calibration
+        from inside a non-default environment (ie from conda/poetry/etc)!
     summa:
         Path to the SUMMA executable
     template:
@@ -92,7 +95,7 @@ class Ostrich():
         Keyword arguments to pass to the simulation run function
     """
 
-    def __init__(self, ostrich_executable, summa_executable, file_manager, python_path='python'):
+    def __init__(self, ostrich_executable, summa_executable, file_manager, python_path=sys.executable):
         """Initialize a new Ostrich object"""
         self.available_metrics: np.ndarray = np.array(['KGE', 'MAE', 'MSE', 'RMSE', 'NSE'])
         self.ostrich: str = ostrich_executable
@@ -109,10 +112,10 @@ class Ostrich():
         self.save_script: Path = self.config_path / 'save_script.py'
         self.metrics_file: Path = self.config_path / 'metrics.txt'
         self.metrics_log: Path = self.config_path / 'metrics_log.csv'
-        self.impot_strings: str = ''
+        self.import_strings: str = ''
         self.conversion_function: callable = lambda x: x
         self.filter_function: callable = lambda x, y: (x, y)
-        self.preserve_output: str ='no'
+        self.preserve_output: str = 'no'
         self.seed: int = 42
         self.errval: float = -9999
         self.perturb_val: float = 0.2
@@ -124,6 +127,9 @@ class Ostrich():
         self.maximize: bool = True
         self.simulation_kwargs: Dict = {}
         self.allow_failures: bool = False
+        self.obs_data_file: str = None
+        self.sim_calib_vars: List = None
+        self.obs_calib_vars: List = None
 
     def run(self, prerun_cmds=[], monitor=True):
         """Start calibration run"""
@@ -132,6 +138,22 @@ class Ostrich():
         else:
             preprocess_cmd = ""
         cmd = preprocess_cmd + f'cd {str(self.config_path)} && ./ostrich'
+        self.cmd = cmd
+        self.process = subprocess.Popen(cmd, stdout=subprocess.PIPE,
+                                        stderr=subprocess.PIPE, shell=True)
+        if monitor:
+            self.stdout, self.stderr = self.process.communicate()
+            if isinstance(self.stdout, bytes):
+                self.stderr = self.stderr.decode('utf-8', 'ignore')
+                self.stdout = self.stdout.decode('utf-8', 'ignore')
+
+    def test_runscript(self, prerun_cmds=[], monitor=True):
+        """Run a single instance of the underlying runscript"""
+        if len(prerun_cmds):
+            preprocess_cmd = " && ".join(prerun_cmds) + " && "
+        else:
+            preprocess_cmd = ""
+        cmd = preprocess_cmd + f'cd {str(self.config_path)} && ./run_script.py'
         self.cmd = cmd
         self.process = subprocess.Popen(cmd, stdout=subprocess.PIPE,
                                         stderr=subprocess.PIPE, shell=True)
@@ -153,6 +175,7 @@ class Ostrich():
 
     def write_config(self):
         """Writes all necessary files for calibration"""
+        self.validate()
         if not os.path.exists(self.config_path):
             os.mkdir(self.config_path)
 
@@ -198,7 +221,8 @@ class Ostrich():
         return Path('.') / file_name
 
     def add_tied_param(self, param_name, lower_bound, upper_bound, initial_value=0.5):
-        self.calib_params.append(OstrichParam(f'{param_name}', initial_value, (0.01, 0.99), weightname=f'{param_name}_scale'))
+        self.calib_params.append(OstrichParam(f'{param_name}', initial_value, (0.01, 0.99),
+                                              weightname=f'{param_name}_scale'))
         self.tied_params.append(OstrichTiedParam(param_name, lower_bound, upper_bound))
 
     @property
@@ -228,6 +252,58 @@ class Ostrich():
         else:
             return '# nothing to do here'
 
+    def open_metrics_log(self):
+        file = str(self.metrics_log)
+        if os.path.exists(file):
+            df = pd.read_csv(file, names=['kge', 'mae', 'mse', 'rmse', 'nse'])
+            return df
+        else:
+            #TODO: Error handling
+            return None
+
+    def open_parameter_log(self):
+        file = str(self.config_path) + '/OstModel0.txt'
+        if os.path.exists(file):
+            df = pd.read_csv(file, delim_whitespace=True)
+            return df
+        else:
+            #TODO: Error handling
+            return None
+
+    def validate(self):
+        """Try to make sure the configuration is usable"""
+
+        # Ensure observation data file exists
+        assert os.path.isfile(self.obs_data_file), \
+            (f"Observed file path doesn't exist!"
+             " You specified {self.obs_data_file}")
+
+        # Ensure the filter function has 2 args
+        filter_fun_args = len(dict(inspect.signature(self.filter_function).parameters))
+        assert filter_fun_args == 2, \
+            (f"The filter function must have two inputs so that it can be applied",
+             " to both the simulated data and the observed data!")
+
+        # Ensure the conversion function has 1 args
+        convert_fun_args = len(dict(inspect.signature(self.conversion_function).parameters))
+        assert convert_fun_args == 1, \
+            (f"The conversion function must have only one input so",
+             " that it can be applied to the observed data!")
+
+        # Ensure variables for calibration match up
+        assert self.sim_calib_vars is not None, "sim_calib_vars cannot be None!"
+        assert self.obs_calib_vars is not None, "obs_calib_vars cannot be None!"
+        if type(self.sim_calib_vars) == str:
+            self.sim_calib_vars = [self.sim_calib_vars]
+        if type(self.obs_calib_vars) == str:
+            self.obs_calib_vars = [self.obs_calib_vars]
+        assert len(self.sim_calib_vars) == len(self.obs_calib_vars), \
+            (f"The number of simulated calibration variables must match",
+             f" the number of observed variables to compare against.",
+             f" You gave {len(self.sim_calib_vars)} and",
+             f" {len(self.obs_calib_vars)}, respectively")
+
+
     @property
     def map_vars_to_template(self):
         """For completion of the OSTRICH input template"""
@@ -251,8 +327,7 @@ class Ostrich():
     @property
     def map_vars_to_save_template(self):
         """For completion of the parameter saving template"""
-        return {
-                'pythonPath': self.python_path,
+        return {'pythonPath': self.python_path,
                 'saveDir': self.config_path.parent / 'best_calibration',
                 'modelDir': self.config_path}
 


### PR DESCRIPTION
# Enhancements
 - Improve usability of Ostrich calibration by adding validation of options before runtime (via the `Ostrich.validate()` method)
 - Improve usability of Ostrich calibration by allowing testing of the runscript (via the `Ostrich.test_runscript()` method)
 - Improve usability of Ostrich calibration by adding helper functions to read in metrics and parameter logs (via the`Ostrich.open_parameter_log()` and `Ostrich.open_metrics_log()` methods
 - Improve usability of Ostrich calibration by attempting to infer the python executable even when running inside of an environment.
 - Allows for user specified cost functions during calibration. 

# Bug fixes
 - Fixes a bug in the Ostrich run script that assumes an `hruIndex` variable in the parameter dataset.
