### PR TITLE
Addition of arguments to ensemble.py and simulation.py for configuration writing. Minor addition file_manager.py

### DIFF
--- a/pysumma/ensemble.py
+++ b/pysumma/ensemble.py
@@ -133,7 +133,7 @@ class Ensemble(object):
 
     def open_output(self):
         """
-        Open all of the output datasets from the ensembe and
+        Open all of the output datasets from the ensemble and
         return as a dictionary of datasets
         """
         return {n: s.output for n, s in self.simulations.items()}
@@ -141,7 +141,7 @@ class Ensemble(object):
 
     def start(self, run_option: str='local',  run_suffix: str='',
               prerun_cmds: list=None, freq_restart: str=None,
-              write_config: bool=True,update_manager: bool=False):
+              write_config: bool=True,write_manager: bool=False):
         """
         Start running the ensemble members.
 
@@ -156,11 +156,11 @@ class Ensemble(object):
             # Sleep calls are to ensure writeout happens
             config = self.configuration[n]
             self.submissions.append(self._client.submit(
-                _submit, s, n, run_option, run_suffix, prerun_cmds, freq_restart,write_config,update_manager,config))
+                _submit, s, n, run_option, run_suffix, prerun_cmds, freq_restart,write_config,write_manager,config))
 
     def run(self, run_option: str='local', run_suffix: str='',
               prerun_cmds: list=None, freq_restart: str=None, write_config: bool=True,
-              update_manager: bool=False, monitor: bool=True):
+              write_manager: bool=False, monitor: bool=True):
         """
         Run the ensemble
 
@@ -173,7 +173,7 @@ class Ensemble(object):
         monitor:
             Whether to halt operation until runs are complete
         """
-        self.start(run_option, run_suffix, prerun_cmds, freq_restart, write_config, update_manager)
+        self.start(run_option, run_suffix, prerun_cmds, freq_restart, write_config, write_manager)
         if monitor:
             return self.monitor()
         else:
@@ -219,7 +219,7 @@ class Ensemble(object):
 
     def rerun_failed(self, run_option: str='local', run_suffix: str='',
               prerun_cmds: list=None, freq_restart: str=None, write_config: bool=True,
-              update_manager: bool=False, monitor: bool=True):
+              write_manager: bool=False, monitor: bool=True):
         """
         Try to re-run failed simulations.
 
@@ -239,19 +239,19 @@ class Ensemble(object):
             s = self.simulations[n]
             s.reset()
             self.submissions.append(self._client.submit(
-                _submit, s, n, run_option, run_suffix, prerun_cmds, freq_restart,write_config,update_manager, config))
+                _submit, s, n, run_option, run_suffix, prerun_cmds, freq_restart,write_config,write_manager, config))
         if monitor:
             return self.monitor()
         else:
             return True
 
 def _submit(s: Simulation, name: str, run_option: str,  run_suffix: str,
-              prerun_cmds: list, freq_restart: str,write_config: bool, update_manager: bool,config: Dict, **kwargs):
+              prerun_cmds: list, freq_restart: str,write_config: bool, write_manager: bool,config: Dict, **kwargs):
     s.initialize()
     s.apply_config(config)
-    s._write_file_manager()
+
     s.run(run_option, run_suffix=run_suffix, freq_restart=freq_restart,
-          write_config=write_config,update_manager=update_manager)
+          write_config=write_config,write_manager=write_manager)
     s.process = None
     return s
 

--- a/pysumma/ensemble.py
+++ b/pysumma/ensemble.py
@@ -92,8 +92,8 @@ class Ensemble(object):
                 decision_dims[k] = v
             for k, v in conf.get('file_manager', {}).items():
                 manager_dims[k] = v
-            #for k, v in conf.get('parameters', {}).items():
-            #    parameter_dims[k] = v
+            for k, v in conf.get('parameters', {}).items():
+                parameter_dims[k] = v
             for k, v in conf.get('trial_parameters', {}).items():
                 parameter_dims[k] = v
         return {'decisions': decision_dims,
@@ -156,11 +156,13 @@ class Ensemble(object):
             # Sleep calls are to ensure writeout happens
             config = self.configuration[n]
             self.submissions.append(self._client.submit(
-                _submit, s, n, run_option, run_suffix, prerun_cmds, freq_restart,write_config,write_manager,config))
+                _submit, s, n, run_option,
+                run_suffix, prerun_cmds, freq_restart,
+                write_config,write_manager,config))
 
     def run(self, run_option: str='local', run_suffix: str='',
-              prerun_cmds: list=None, freq_restart: str=None, write_config: bool=True,
-              write_manager: bool=False, monitor: bool=True):
+            prerun_cmds: list=None, freq_restart: str=None, write_config: bool=True,
+            write_manager: bool=False, monitor: bool=True):
         """
         Run the ensemble
 
@@ -173,7 +175,8 @@ class Ensemble(object):
         monitor:
             Whether to halt operation until runs are complete
         """
-        self.start(run_option, run_suffix, prerun_cmds, freq_restart, write_config, write_manager)
+        self.start(run_option, run_suffix, prerun_cmds,
+                   freq_restart, write_config, write_manager)
         if monitor:
             return self.monitor()
         else:
@@ -195,10 +198,12 @@ class Ensemble(object):
 
     def monitor(self):
         """
-        Halt computation until submitted simulations are complete
+        Halt computation until submitted simulations are complete.
+        Update submission name from config.
+
         """
         simulations = self._client.gather(self.submissions)
-        names = [n for n,s in self.simulations.items()]
+        names = self.simulations.keys()
 
         for s,name in zip(simulations,names):
             self.simulations[name] = s
@@ -239,14 +244,22 @@ class Ensemble(object):
             s = self.simulations[n]
             s.reset()
             self.submissions.append(self._client.submit(
-                _submit, s, n, run_option, run_suffix, prerun_cmds, freq_restart,write_config,write_manager, config))
+                _submit, s, n, run_option, run_suffix,
+                prerun_cmds, freq_restart,write_config,
+                write_manager, config))
+
         if monitor:
             return self.monitor()
         else:
             return True
 
 def _submit(s: Simulation, name: str, run_option: str,  run_suffix: str,
-              prerun_cmds: list, freq_restart: str,write_config: bool, write_manager: bool,config: Dict, **kwargs):
+            prerun_cmds: list, freq_restart: str,write_config: bool,
+            write_manager: bool,config: Dict, **kwargs):
+    """
+    Run simulation objects
+    """
+
     s.initialize()
     s.apply_config(config)
 

--- a/pysumma/file_manager.py
+++ b/pysumma/file_manager.py
@@ -108,7 +108,10 @@ class FileManager(OptionContainer):
 
     @property
     def initial_conditions(self):
-        p1 = self.get_value('settingsPath')
+        if self.get_value('statePath'):
+            p1 = self.get_value('statePath')
+        else:
+            p1 = self.get_value('settingsPath')
         p2 = self.get_value('initConditionFile')
         with xr.open_dataset(p1 + p2) as self._init_cond:
         	self._init_cond.load()

--- a/pysumma/simulation.py
+++ b/pysumma/simulation.py
@@ -304,7 +304,7 @@ class Simulation():
 
     def start(self, run_option='local',  run_suffix='pysumma_run', processes=1,
               prerun_cmds=[], startGRU=None, countGRU=None, iHRU=None,
-              freq_restart=None, write_config=True,update_manager=False, progress=None, **kwargs):
+              freq_restart=None, write_config=True,write_manager=False, progress=None, **kwargs):
         """
         Run a SUMMA simulation without halting. Most likely this should
         not be used. Use the ``run`` method for most common use cases.
@@ -315,7 +315,7 @@ class Simulation():
         self.run_suffix = run_suffix
         if write_config:
             self._write_configuration(name=run_suffix)
-        if update_manager:
+        if write_manager:
             self._write_file_manager()
         if run_option == 'local':
             self._run_local(run_suffix, processes, prerun_cmds,
@@ -329,7 +329,7 @@ class Simulation():
 
     def run(self, run_option='local',  run_suffix='pysumma_run', processes=1,
             prerun_cmds=None, startGRU=None, countGRU=None, iHRU=None,
-            freq_restart=None, write_config=True,update_manager=False,progress=None, **kwargs):
+            freq_restart=None, write_config=True,write_manager=False,progress=None, **kwargs):
         """
         Run a SUMMA simulation and halt until completion or error.
 
@@ -365,7 +365,7 @@ class Simulation():
             hourly output.
         """
         self.start(run_option, run_suffix, processes, prerun_cmds,
-                   startGRU, countGRU, iHRU, freq_restart,write_config, update_manager, progress, **kwargs)
+                   startGRU, countGRU, iHRU, freq_restart,write_config, write_manager, progress, **kwargs)
         self.monitor()
 
     def monitor(self):
@@ -458,7 +458,6 @@ class Simulation():
             f.writelines(self.vegparm)
 
     def _write_file_manager(self, name=''):
-
         self.manager.write(path=self.config_path.parent)
 
     def get_forcing_data_list(self) -> List[xr.Dataset]:

--- a/pysumma/simulation.py
+++ b/pysumma/simulation.py
@@ -114,6 +114,8 @@ class Simulation():
         """
         if 'file_manager' in config:
             self.manager_path = Path(os.path.abspath(config['file_manager']))
+        for k, v in config.get('manager', {}).items():
+            self.manager.set_option(k, v)
         for k, v in config.get('decisions', {}).items():
             self.decisions.set_option(k, v)
         for k, v in config.get('parameters', {}).items():
@@ -302,7 +304,7 @@ class Simulation():
 
     def start(self, run_option='local',  run_suffix='pysumma_run', processes=1,
               prerun_cmds=[], startGRU=None, countGRU=None, iHRU=None,
-              freq_restart=None, progress=None, **kwargs):
+              freq_restart=None, write_config=True,update_manager=False, progress=None, **kwargs):
         """
         Run a SUMMA simulation without halting. Most likely this should
         not be used. Use the ``run`` method for most common use cases.
@@ -311,7 +313,10 @@ class Simulation():
         if not prerun_cmds:
             prerun_cmds = []
         self.run_suffix = run_suffix
-        self._write_configuration(name=run_suffix)
+        if write_config:
+            self._write_configuration(name=run_suffix)
+        if update_manager:
+            self._write_file_manager()
         if run_option == 'local':
             self._run_local(run_suffix, processes, prerun_cmds,
                             startGRU, countGRU, iHRU, freq_restart, progress)
@@ -324,7 +329,7 @@ class Simulation():
 
     def run(self, run_option='local',  run_suffix='pysumma_run', processes=1,
             prerun_cmds=None, startGRU=None, countGRU=None, iHRU=None,
-            freq_restart=None, progress=None, **kwargs):
+            freq_restart=None, write_config=True,update_manager=False,progress=None, **kwargs):
         """
         Run a SUMMA simulation and halt until completion or error.
 
@@ -360,7 +365,7 @@ class Simulation():
             hourly output.
         """
         self.start(run_option, run_suffix, processes, prerun_cmds,
-                   startGRU, countGRU, iHRU, freq_restart, progress, **kwargs)
+                   startGRU, countGRU, iHRU, freq_restart,write_config, update_manager, progress, **kwargs)
         self.monitor()
 
     def monitor(self):
@@ -451,6 +456,10 @@ class Simulation():
             f.writelines(self.soilparm)
         with open(settings_path / self.manager['vegTableFile'].value, 'w+') as f:
             f.writelines(self.vegparm)
+
+    def _write_file_manager(self, name=''):
+
+        self.manager.write(path=self.config_path.parent)
 
     def get_forcing_data_list(self) -> List[xr.Dataset]:
         return self.force_file_list.open_forcing_data()

--- a/pysumma/simulation.py
+++ b/pysumma/simulation.py
@@ -304,7 +304,8 @@ class Simulation():
 
     def start(self, run_option='local',  run_suffix='pysumma_run', processes=1,
               prerun_cmds=[], startGRU=None, countGRU=None, iHRU=None,
-              freq_restart=None, write_config=True,write_manager=False, progress=None, **kwargs):
+              freq_restart=None, write_config=True,write_manager=False,
+              progress=None, **kwargs):
         """
         Run a SUMMA simulation without halting. Most likely this should
         not be used. Use the ``run`` method for most common use cases.
@@ -329,7 +330,8 @@ class Simulation():
 
     def run(self, run_option='local',  run_suffix='pysumma_run', processes=1,
             prerun_cmds=None, startGRU=None, countGRU=None, iHRU=None,
-            freq_restart=None, write_config=True,write_manager=False,progress=None, **kwargs):
+            freq_restart=None, write_config=True,write_manager=False,
+            progress=None, **kwargs):
         """
         Run a SUMMA simulation and halt until completion or error.
 
@@ -365,7 +367,8 @@ class Simulation():
             hourly output.
         """
         self.start(run_option, run_suffix, processes, prerun_cmds,
-                   startGRU, countGRU, iHRU, freq_restart,write_config, write_manager, progress, **kwargs)
+                   startGRU, countGRU, iHRU, freq_restart,write_config,
+                   write_manager, progress, **kwargs)
         self.monitor()
 
     def monitor(self):


### PR DESCRIPTION
The focus of the changes is the addition of options to ensemble and simulation to allow specification of the frequency of restart, writing the configuration, to allow the whole configuration not to be written and for the file manager alone to be updated.

Changes are also made to avoid the automatic use of the run_suffix for naming the simulation object. This is problematic for daily timestepping, where the suffix is consistent between ensemble members.

file_manager is update to allow the statePath to be specified and used.